### PR TITLE
Modified with option to show/hide notification message.

### DIFF
--- a/notification_center.py
+++ b/notification_center.py
@@ -1,9 +1,5 @@
 # https://github.com/sindresorhus/weechat-notification-center
 # Requires `pip install pync`
-# Author: Sindre Sorhus <sindresorhus@gmail.com>
-# License: MIT
-
-# Modified with option to show/hide notification message
 
 import weechat
 from pync import Notifier


### PR DESCRIPTION
For the same privacy reasons there are checkboxes in Mail/Facetime/Messages Notifications to turn off Message Preview in both OS X and in iOS.
