### PR TITLE
Some improvements 

### DIFF
--- a/notification_center.py
+++ b/notification_center.py
@@ -1,5 +1,10 @@
 # https://github.com/sindresorhus/weechat-notification-center
 # Requires `pip install pync`
+#
+# Updated by Gianni Van Hoecke:
+#  - Option to show all messages
+#  - Updated titles to be more clear
+#
 
 import weechat
 from pync import Notifier
@@ -17,22 +22,23 @@ DEFAULT_OPTIONS = {
 	'show_highlights': 'on',
 	'show_private_message': 'on',
 	'show_message_text': 'on',
-	'sound': 'off',
+	'show_other_message': 'on',
+	'sound': 'on',
+	'sound_on_other_message': 'off'
 }
 
 for key, val in DEFAULT_OPTIONS.items():
 	if not weechat.config_is_set_plugin(key):
 		weechat.config_set_plugin(key, val)
 
-weechat.hook_print('', 'irc_privmsg', '', 1, 'notify', '')
-
 def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 	# passing `None` or `''` still plays the default sound so we pass a lambda instead
 	sound = 'Pong' if weechat.config_get_plugin('sound') == 'on' else lambda:_
-	if weechat.config_get_plugin('show_highlights') == 'on' and highlight == '1':
-		channel = weechat.buffer_get_string(buffer, 'localvar_channel')
+	sound_on_other_message = 'Pong' if weechat.config_get_plugin('sound_on_other_message') == 'on' else lambda:_
+	channel = weechat.buffer_get_string(buffer, 'localvar_channel')
+	if weechat.config_get_plugin('show_highlights') == 'on' and int(highlight):
 		if weechat.config_get_plugin('show_message_text') == 'on':
-			Notifier.notify(message, title='%s %s' % (prefix, channel), sound=sound)
+			Notifier.notify(message, title='Highlighted by %s in %s' % (prefix, channel), sound=sound)
 		else:
 			Notifier.notify('In %s by %s' % (channel, prefix), title='Highlighted Message', sound=sound)
 	elif weechat.config_get_plugin('show_private_message') == 'on' and 'notify_private' in tags:
@@ -40,4 +46,8 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 			Notifier.notify(message, title='%s [private]' % prefix, sound=sound)
 		else:
 			Notifier.notify('From %s' % prefix, title='Private Message', sound=sound)
+	elif weechat.config_get_plugin('show_other_message') == 'on':
+		Notifier.notify(message, title='By %s in %s' % (prefix, channel), sound=sound_on_other_message)
 	return weechat.WEECHAT_RC_OK
+  
+weechat.hook_print('', 'irc_privmsg', '', 1, 'notify', '')

--- a/notification_center.py
+++ b/notification_center.py
@@ -32,10 +32,22 @@ for key, val in DEFAULT_OPTIONS.items():
 		weechat.config_set_plugin(key, val)
 
 def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
-	# passing `None` or `''` still plays the default sound so we pass a lambda instead
+
+	#If own nickname is sender, ignore
+	mynick = weechat.buffer_get_string(buffer,'localvar_nick')
+	if prefix == mynick or prefix == ('@%s' % mynick):
+		return weechat.WEECHAT_RC_OK
+
+	#Format message
+	message = repr(message.encode('string-escape'))
+
+	#Passing `None` or `''` still plays the default sound so we pass a lambda instead
 	sound = 'Pong' if weechat.config_get_plugin('sound') == 'on' else lambda:_
 	sound_on_other_message = 'Pong' if weechat.config_get_plugin('sound_on_other_message') == 'on' else lambda:_
+
 	channel = weechat.buffer_get_string(buffer, 'localvar_channel')
+
+	#Send notification
 	if weechat.config_get_plugin('show_highlights') == 'on' and int(highlight):
 		if weechat.config_get_plugin('show_message_text') == 'on':
 			Notifier.notify(message, title='Highlighted by %s in %s' % (prefix, channel), sound=sound)
@@ -48,6 +60,7 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 			Notifier.notify('From %s' % prefix, title='Private Message', sound=sound)
 	elif weechat.config_get_plugin('show_other_message') == 'on':
 		Notifier.notify(message, title='By %s in %s' % (prefix, channel), sound=sound_on_other_message)
+
 	return weechat.WEECHAT_RC_OK
   
 weechat.hook_print('', 'irc_privmsg', '', 1, 'notify', '')

--- a/notification_center.py
+++ b/notification_center.py
@@ -59,8 +59,10 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 		else:
 			Notifier.notify('From %s' % prefix, title='Private Message', sound=sound)
 	elif weechat.config_get_plugin('show_other_message') == 'on':
-		Notifier.notify(message, title='By %s in %s' % (prefix, channel), sound=sound_on_other_message)
-
+		if weechat.config_get_plugin('show_message_text') == 'on':
+			Notifier.notify(message, title='By %s in %s' % (prefix, channel), sound=sound_on_other_message)
+		else:
+			Notifier.notify('In %s by %s' % (channel, prefix), title='New Message', sound=sound_on_other_message)
 	return weechat.WEECHAT_RC_OK
   
 weechat.hook_print('', 'irc_privmsg', '', 1, 'notify', '')

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,9 @@
 
 > [WeeChat](http://www.weechat.org) script to pass highlights and private messages to the OS X 10.8+ Notification Center.
 
+Forked and adapted:
+- Option to show all messages
+- Updated titles to be more clear
 
 ## Install
 


### PR DESCRIPTION
- In my (default) Mac OS X setup highlighted messages didn't came through, fixed by casting highlight -> int(highlight)
- Clearer titles
- New option to show all other messages with a different sound setting
- Don't show notification if message comes from own nickname