### PR TITLE
Make sound name configurable.

### DIFF
--- a/notification_center.py
+++ b/notification_center.py
@@ -18,6 +18,7 @@ DEFAULT_OPTIONS = {
 	'show_private_message': 'on',
 	'show_message_text': 'on',
 	'sound': 'off',
+	'sound_name': 'Pong',
 }
 
 for key, val in DEFAULT_OPTIONS.items():
@@ -33,7 +34,7 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 		return weechat.WEECHAT_RC_OK
 
 	# passing `None` or `''` still plays the default sound so we pass a lambda instead
-	sound = 'Pong' if weechat.config_get_plugin('sound') == 'on' else lambda:_
+	sound = weechat.config_get_plugin('sound_name') if weechat.config_get_plugin('sound') == 'on' else lambda:_
 	if weechat.config_get_plugin('show_highlights') == 'on' and int(highlight):
 		channel = weechat.buffer_get_string(buffer, 'localvar_channel')
 		if weechat.config_get_plugin('show_message_text') == 'on':

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,13 @@
 - Install [pync](https://github.com/SeTeM/pync): `pip install pync`
 - Copy or symlink `notification_center.py` into `~/.weechat/python/autoload/`
 
+## Options
+
+- show_highlights, defaults to on, valid values are on and off.
+- show_private_message, defaults to on, valid values are on and off.
+- show_message_text, defaults to on, valid values are on and off.
+- sound, defaults to off, valid values are on and off.
+- sound_name, defaults to Pong, valid values as of OS X 10.11 are Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sosumi, Submarine, Tink, but can really be anything that has an aptly named sound file in `/System/Library/Sounds/`, `/Library/Sounds/`, or `~/Library/Sounds/`.
 
 ## License
 


### PR DESCRIPTION
I recently migrated to weechat and I'd like to keep using the notification sound I've grown accustomed to from my previous IRC client.