### PR TITLE
Add option to ignore old messages

### DIFF
--- a/notification_center.py
+++ b/notification_center.py
@@ -24,7 +24,6 @@ DEFAULT_OPTIONS = {
 	'sound_name': 'Pong',
 	'activate_bundle_id': 'com.apple.Terminal',
 	'ignore_old_messages': 'off',
-	'old_message_threshold': '60'
 }
 
 for key, val in DEFAULT_OPTIONS.items():
@@ -41,11 +40,11 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 
 	# ignore messages older than the configured theshold (such as ZNC logs) if enabled
 	if weechat.config_get_plugin('ignore_old_messages') == 'on':
-		old_threshold = int(weechat.config_get_plugin('old_message_threshold'))
                 message_time = datetime.datetime.utcfromtimestamp(int(date))
                 now_time = datetime.datetime.utcnow()
 
-                if (now_time - message_time).seconds > old_threshold:
+		# ignore if the message is greater than 5 seconds old
+                if (now_time - message_time).seconds > 5:
                         return weechat.WEECHAT_RC_OK
 
 	# passing `None` or `''` still plays the default sound so we pass a lambda instead

--- a/notification_center.py
+++ b/notification_center.py
@@ -39,8 +39,8 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 	if prefix == own_nick or prefix == ('@%s' % own_nick):
 		return weechat.WEECHAT_RC_OK
 
-        # ignore messages older than the configured theshold (such as ZNC logs) if enabled
-        if weechat.config_get_plugin('ignore_old_messages') == 'on':
+	# ignore messages older than the configured theshold (such as ZNC logs) if enabled
+	if weechat.config_get_plugin('ignore_old_messages') == 'on':
 		old_threshold = int(weechat.config_get_plugin('old_message_threshold'))
                 message_time = datetime.datetime.utcfromtimestamp(int(date))
                 now_time = datetime.datetime.utcnow()

--- a/notification_center.py
+++ b/notification_center.py
@@ -23,7 +23,7 @@ DEFAULT_OPTIONS = {
 	'sound': 'off',
 	'sound_name': 'Pong',
 	'activate_bundle_id': 'com.apple.Terminal',
-        'ignore_old_messages': 'off',
+	'ignore_old_messages': 'off',
 	'old_message_threshold': '60'
 }
 

--- a/notification_center.py
+++ b/notification_center.py
@@ -2,6 +2,7 @@
 # Requires `pip install pync`
 
 import os
+import datetime
 import weechat
 from pync import Notifier
 
@@ -22,6 +23,8 @@ DEFAULT_OPTIONS = {
 	'sound': 'off',
 	'sound_name': 'Pong',
 	'activate_bundle_id': 'com.apple.Terminal',
+        'ignore_old_messages': 'off',
+	'old_message_threshold': '60'
 }
 
 for key, val in DEFAULT_OPTIONS.items():
@@ -35,6 +38,15 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 	own_nick = weechat.buffer_get_string(buffer, 'localvar_nick')
 	if prefix == own_nick or prefix == ('@%s' % own_nick):
 		return weechat.WEECHAT_RC_OK
+
+        # ignore messages older than the configured theshold (such as ZNC logs) if enabled
+        if weechat.config_get_plugin('ignore_old_messages') == 'on':
+		old_threshold = int(weechat.config_get_plugin('old_message_threshold'))
+                message_time = datetime.datetime.utcfromtimestamp(int(date))
+                now_time = datetime.datetime.utcnow()
+
+                if (now_time - message_time).seconds > old_threshold:
+                        return weechat.WEECHAT_RC_OK
 
 	# passing `None` or `''` still plays the default sound so we pass a lambda instead
 	sound = weechat.config_get_plugin('sound_name') if weechat.config_get_plugin('sound') == 'on' else lambda:_

--- a/readme.md
+++ b/readme.md
@@ -64,13 +64,6 @@ Values: `'on'`, `'off'`
 
 Determines whether old messages, such as log playbacks, will trigger notifications or not.
 
-### old_message_threshold
-
-Default: `'60'`
-Values: `'1'`, `'2'`, ...
-
-Determines how old a message must be, in seconds, for it to be ignored by `ignore_old_messages`.
-
 ## License
 
 MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/readme.md
+++ b/readme.md
@@ -62,14 +62,14 @@ The app bundle ID can be found in `/Applications/<MyTerminal>.app/Contents/Info.
 Default: `'off'`
 Values: `'on'`, `'off'`
 
-Determines whether old messages, such as log playbacks, will trigger notifications or not
+Determines whether old messages, such as log playbacks, will trigger notifications or not.
 
 ### old_message_threshold
 
 Default: `'60'`
 Values: `'1'`, `'2'`, ...
 
-Determines how old a message must be, in seconds, for it to be ignored by `ignore_old_messages`
+Determines how old a message must be, in seconds, for it to be ignored by `ignore_old_messages`.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,19 @@ App to activate when the notification is clicked.
 
 The app bundle ID can be found in `/Applications/<MyTerminal>.app/Contents/Info.plist`, right below the `CFBundleIdentifier` key.
 
+### ignore_old_messages
+
+Default: `'off'`
+Values: `'on'`, `'off'`
+
+Determines whether old messages, such as log playbacks, will trigger notifications or not
+
+### old_message_threshold
+
+Default: `'60'`
+Values: `'1'`, `'2'`, ...
+
+Determines how old a message must be, in seconds, for it to be ignored by `ignore_old_messages`
 
 ## License
 


### PR DESCRIPTION
This adds two new config options that allow old messages, such as those from a ZNC log, to be ignored by the notifier.

It fixes a particular problem I have (notification flood on reconnect), but I've left it disabled by default as some users might prefer notifications from logs