### PR TITLE
Let notification_center send notifications for all highlights (including #channels)

### DIFF
--- a/notification_center.py
+++ b/notification_center.py
@@ -30,7 +30,7 @@ for key, val in DEFAULT_OPTIONS.items():
 	if not weechat.config_is_set_plugin(key):
 		weechat.config_set_plugin(key, val)
 
-weechat.hook_print('', 'irc_privmsg', '', 1, 'notify', '')
+weechat.hook_print('', ', '', 1, 'notify', '')
 
 def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 	# ignore if it's yourself


### PR DESCRIPTION
See title. `notification_center.py` doesn't currently send notifications for highlights in channels.