### PR TITLE
Add option to ignore messages from the current buffer

### DIFF
--- a/notification_center.py
+++ b/notification_center.py
@@ -39,7 +39,7 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 	if prefix == own_nick or prefix == ('@%s' % own_nick):
 		return weechat.WEECHAT_RC_OK
 
-	# ignore messages from current buffer
+	# ignore messages from the current buffer
 	if weechat.config_get_plugin('ignore_current_buffer_messages') == 'on' and buffer == weechat.current_buffer():
 		return weechat.WEECHAT_RC_OK
 

--- a/notification_center.py
+++ b/notification_center.py
@@ -24,6 +24,7 @@ DEFAULT_OPTIONS = {
 	'sound_name': 'Pong',
 	'activate_bundle_id': 'com.apple.Terminal',
 	'ignore_old_messages': 'off',
+	'ignore_current_buffer_messages': 'off',
 }
 
 for key, val in DEFAULT_OPTIONS.items():
@@ -36,6 +37,10 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 	# ignore if it's yourself
 	own_nick = weechat.buffer_get_string(buffer, 'localvar_nick')
 	if prefix == own_nick or prefix == ('@%s' % own_nick):
+		return weechat.WEECHAT_RC_OK
+
+	# ignore messages from current buffer
+	if weechat.config_get_plugin('ignore_current_buffer_messages') == 'on' and buffer == weechat.current_buffer():
 		return weechat.WEECHAT_RC_OK
 
 	# ignore messages older than the configured theshold (such as ZNC logs) if enabled

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Determines whether old messages, such as log playbacks, will trigger notificatio
 Default: `'off'`<br>
 Values: `'on'`, `'off'`
 
-Determines whether messages from the current buffer should trigger notifications or not.
+Determines whether messages from the current buffer should trigger notifications or not. This is useful especially if you use [wee-slack](https://github.com/wee-slack/wee-slack), and receive notifications for messages they send, as discussed in [#22](https://github.com/sindresorhus/weechat-notification-center/issues/22).
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Determines whether old messages, such as log playbacks, will trigger notificatio
 Default: `'off'`<br>
 Values: `'on'`, `'off'`
 
-Determines whether messages from the current buffer should trigger notifications or not. This is useful especially if you use [wee-slack](https://github.com/wee-slack/wee-slack), and receive notifications for messages they send, as discussed in [#22](https://github.com/sindresorhus/weechat-notification-center/issues/22).
+Determines whether messages from the current buffer should trigger notifications or not. This is especially useful if you use [wee-slack](https://github.com/wee-slack/wee-slack) and receive notifications for messages they send, as discussed in [#22](https://github.com/sindresorhus/weechat-notification-center/issues/22).
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,12 @@ Values: `'on'`, `'off'`
 
 Determines whether old messages, such as log playbacks, will trigger notifications or not.
 
+### ignore_current_buffer_messages
+
+Default: `'off'`<br>
+Values: `'on'`, `'off'`
+
+Determines whether messages from the current buffer should trigger notifications or not.
 
 ## License
 


### PR DESCRIPTION
This is useful especially for wee-slack users because wee-slack doesn't
seem to export the `localvar_nick` variable needed to ignore messages from
yourself.

Fixes #22.