### PR TITLE
Allow whitelisted channels to notify on all messages

### DIFF
--- a/notification_center.py
+++ b/notification_center.py
@@ -25,6 +25,7 @@ DEFAULT_OPTIONS = {
 	'activate_bundle_id': 'com.apple.Terminal',
 	'ignore_old_messages': 'off',
 	'ignore_current_buffer_messages': 'off',
+	'channels': '',
 }
 
 for key, val in DEFAULT_OPTIONS.items():
@@ -55,8 +56,15 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 	# passing `None` or `''` still plays the default sound so we pass a lambda instead
 	sound = weechat.config_get_plugin('sound_name') if weechat.config_get_plugin('sound') == 'on' else lambda:_
 	activate_bundle_id = weechat.config_get_plugin('activate_bundle_id')
-	if weechat.config_get_plugin('show_highlights') == 'on' and int(highlight):
-		channel = weechat.buffer_get_string(buffer, 'localvar_channel')
+
+	channel_whitelist = weechat.config_get_plugin('channels').split(',')
+	channel = weechat.buffer_get_string(buffer, 'localvar_channel')
+	if channel in channel_whitelist:
+		if weechat.config_get_plugin('show_message_text') == 'on':
+			Notifier.notify(message, title='%s %s' % (prefix, channel), sound=sound, appIcon=WEECHAT_ICON, activate=activate_bundle_id)
+		else:
+			Notifier.notify('In %s by %s' % (channel, prefix), title='Channel Activity', sound=sound, appIcon=WEECHAT_ICON, activate=activate_bundle_id)
+	elif weechat.config_get_plugin('show_highlights') == 'on' and int(highlight):
 		if weechat.config_get_plugin('show_message_text') == 'on':
 			Notifier.notify(message, title='%s %s' % (prefix, channel), sound=sound, appIcon=WEECHAT_ICON, activate=activate_bundle_id)
 		else:

--- a/readme.md
+++ b/readme.md
@@ -70,3 +70,10 @@ Default: `'off'`<br>
 Values: `'on'`, `'off'`
 
 Determines whether messages from the current buffer should trigger notifications or not. This is especially useful if you use [wee-slack](https://github.com/wee-slack/wee-slack) and receive notifications for messages they send, as discussed in [#22](https://github.com/sindresorhus/weechat-notification-center/issues/22).
+
+### channels
+
+Default: `''`<br>
+Values: Comma-separated list of channel names
+
+Channels in this list will trigger a notification on every message received.


### PR DESCRIPTION
This adds a new option `channels`. Channels specified in the `channels` option (separated by commas) will create notifications for all new messages.