### PR TITLE
Allow additional tags that can trigger notify

### DIFF
--- a/notification_center.py
+++ b/notification_center.py
@@ -26,13 +26,14 @@ DEFAULT_OPTIONS = {
 	'ignore_old_messages': 'off',
 	'ignore_current_buffer_messages': 'off',
 	'channels': '',
+	'tags': '',
 }
 
 for key, val in DEFAULT_OPTIONS.items():
 	if not weechat.config_is_set_plugin(key):
 		weechat.config_set_plugin(key, val)
 
-weechat.hook_print('', 'irc_privmsg', '', 1, 'notify', '')
+weechat.hook_print('', 'irc_privmsg,' + weechat.config_get_plugin('tags'), '', 1, 'notify', '')
 
 def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 	# ignore if it's yourself
@@ -69,7 +70,7 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 			Notifier.notify(message, title='%s %s' % (prefix, channel), sound=sound, appIcon=WEECHAT_ICON, activate=activate_bundle_id)
 		else:
 			Notifier.notify('In %s by %s' % (channel, prefix), title='Highlighted Message', sound=sound, appIcon=WEECHAT_ICON, activate=activate_bundle_id)
-	elif weechat.config_get_plugin('show_private_message') == 'on' and 'notify_private' in tags:
+	elif weechat.config_get_plugin('show_private_message') == 'on' and 'irc_privmsg' in tags and 'notify_private' in tags:
 		if weechat.config_get_plugin('show_message_text') == 'on':
 			Notifier.notify(message, title='%s [private]' % prefix, sound=sound, appIcon=WEECHAT_ICON, activate=activate_bundle_id)
 		else:

--- a/readme.md
+++ b/readme.md
@@ -77,3 +77,16 @@ Default: `''`<br>
 Values: Comma-separated list of channel names
 
 Channels in this list will trigger a notification on every message received.
+
+### tags
+
+Default: `''`<br>
+Values: comma-separated list of tags
+
+Additional message tags that can trigger notifications. This can be used in combination with `weechat.look.highlight_tags` to generate custom notifications.
+
+For example, to get notifications when `<nick>` joins or parts `<server>`:
+
+    /notify add <nick> <server>
+    /set weechat.look.highlight_tags "irc_notify_join,irc_notify_quit"
+    /set plugins.var.notification_center.tags "irc_notify"

--- a/readme.md
+++ b/readme.md
@@ -81,12 +81,14 @@ Channels in this list will trigger a notification on every message received.
 ### tags
 
 Default: `''`<br>
-Values: comma-separated list of tags
+Values: Comma-separated list of tags
 
-Additional message tags that can trigger notifications. This can be used in combination with `weechat.look.highlight_tags` to generate custom notifications.
+Additional [message tags](https://weechat.org/files/doc/stable/weechat_user.en.html#lines_tags) that can trigger notifications. This can be used in combination with [`weechat.look.highlight_tags`](https://weechat.org/files/doc/stable/weechat_user.en.html#option_weechat.look.highlight_tags) to generate custom notifications.
 
 For example, to get notifications when `<nick>` joins or parts `<server>`:
 
-    /notify add <nick> <server>
-    /set weechat.look.highlight_tags "irc_notify_join,irc_notify_quit"
-    /set plugins.var.notification_center.tags "irc_notify"
+```
+/notify add <nick> <server>
+/set weechat.look.highlight_tags "irc_notify_join,irc_notify_quit"
+/set plugins.var.notification_center.tags "irc_notify"
+```


### PR DESCRIPTION
This (optionally) allows further message tags to trigger the `notify()` method. This can be used in conjunction with `weechat.look.highlight_tags` to generate notifications for any kind of desired message (e.g. join/part messages for other users).

This change will have **no effect** if the default option is left unchanged.