### PR TITLE
Fix the `channels` option

### DIFF
--- a/notification_center.py
+++ b/notification_center.py
@@ -58,8 +58,11 @@ def notify(data, buffer, date, tags, displayed, highlight, prefix, message):
 	sound = weechat.config_get_plugin('sound_name') if weechat.config_get_plugin('sound') == 'on' else lambda:_
 	activate_bundle_id = weechat.config_get_plugin('activate_bundle_id')
 
-	channel_whitelist = weechat.config_get_plugin('channels').split(',')
+	channel_whitelist = []
+	if weechat.config_get_plugin('channels') != "":
+		channel_whitelist = weechat.config_get_plugin('channels').split(',')
 	channel = weechat.buffer_get_string(buffer, 'localvar_channel')
+
 	if channel in channel_whitelist:
 		if weechat.config_get_plugin('show_message_text') == 'on':
 			Notifier.notify(message, title='%s %s' % (prefix, channel), sound=sound, appIcon=WEECHAT_ICON, activate=activate_bundle_id)


### PR DESCRIPTION
When python.notification_center.channels is set as "" in ~/.weechat/plugins.conf, notification_center.py doesn't work.
I investigated this issue and noticed `if channel in channel_whitelist:` of [line 63](https://github.com/sindresorhus/weechat-notification-center/blob/master/notification_center.py#L63) returns True although channel whitelist is not registered.
In Python, `"".split(',') ` returns `['']` and `"" in ['']` returns `True`....

To avoid the case, condition is set.

```python
$ python
Python 3.8.1 (default, Feb  8 2020, 23:24:07)
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> "" in []
False
>>> "" in ['']
True
>>> whitelist = "".split(',')
>>> print (whitelist)
['']
>>> "" in whitelist
True
```

I confirmed the edited version of notification-center.py works in weechat.
If you would like to ask me more in detail, please let me know.